### PR TITLE
Inverted switch and icon for blinds

### DIFF
--- a/www/js/mobile.js
+++ b/www/js/mobile.js
@@ -692,7 +692,8 @@ var mobile = {
                                 rawVal = Math.round((rawVal - min) * 100 / (max - min));
                                 rawVal = Math.round(rawVal / 10) * 10;
 
-                                img = 'img/blind' + rawVal + '.png';
+                                var imgVal = 100 - rawVal;  // invert values, in HM 100% means: completely open
+                                img = 'img/blind' + imgVal + '.png';
                                 break;
 
                             default:

--- a/www/js/mobile.js
+++ b/www/js/mobile.js
@@ -866,8 +866,8 @@ var mobile = {
         var roles = obj.common.role ? obj.common.role.split('.') : [];
 
         if (roles.indexOf('blind') !== -1 || stateName === 'OPEN' || stateName === 'CLOSE') {
-            on  = 'closed';
-            off = 'opened';
+            on  = 'opened';
+            off = 'closed';
         }
 
         // add for blinds and dimmer on/off switch


### PR DESCRIPTION
Hi Bluefox,

mit ist aufgefallen, dass die Darstellung des Schalters und des Symbols bei Jalousien nicht ganz korrekt ist. Innerhalb der CCU bzw. bei Homematic steht 100% für “auf“, d.h. für maximalen Lichteinfall. Bislang wurde in der Mobile-UI aber bei 100% ein geschlossenes Symbol bzw. auch der aktivierte Status “zu“ angezeigt.

Viele Grüße

Bastian