### PR TITLE
Increased version number

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,13 @@
 {
     "common": {
-        "name":                     "mobile",
-        "version": "0.4.10",
+        "name": "mobile",
+        "version": "0.4.11",
         "news": {
+            "0.4.11": {
+                "en": "Fixed blind states",
+                "de": "Rolladenstatus korrigiert",
+                "ru": "Исправлены слепые состояния"
+            },
             "0.4.10": {
                 "en": "Better support of cloud",
                 "de": "Bessere cloud Unterstützung",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iobroker.mobile",
   "description": "jQuery Mobile based ioBroker user interface",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "author": {
     "name": "bluefox",
     "email": "dogafox@gmail.com"


### PR DESCRIPTION
Hi Bluefox,

ich habe im mobile-Adapter mal die Versionsnummer hochgesetzt, so dass die korrigierte Version der Rolladen (offen -> zu, zu -> offen, entsprechende Symbole) per Update und nicht nur für Neuinstallationen zur Verfügung steht.

VG

Bastian
